### PR TITLE
Added search route testing

### DIFF
--- a/__tests__/search.routes.server.test.ts
+++ b/__tests__/search.routes.server.test.ts
@@ -1,0 +1,60 @@
+const request = require('supertest');
+import server from '../server/server';
+// const serverUrl = 'http://localhost:3000';
+
+console.log = jest.fn();
+
+describe('Testing /search routes', () => {
+  afterAll(() => {
+    server.close();
+  });
+
+  describe('Testing /search query route', () => {
+    it('Can make search requests', () => {
+      return request(server)
+      .get('/search?page=1&locations=new%20york%20city&keywords=fullstack')
+      .expect('Content-Type', /application\/json/)
+      .expect(200)
+      .expect(function(res) {
+        expect(res.body).toBeInstanceOf(Array);
+      });
+    });
+
+    it('Returns error condition when missing "page"', () => {
+      return request(server)
+      .get('/search?locations=new%20york%20city&keywords=fullstack')
+      .expect('Content-Type', /application\/json/)
+      .expect(401);
+    });
+
+    it('Returns error condition when missing "location"', () => {
+      return request(server)
+      .get('/search?page=1&keywords=fullstack')
+      .expect('Content-Type', /application\/json/)
+      .expect(401);
+    });
+
+    it('Returns error condition when missing "keywords"', () => {
+      return request(server)
+      .get('/search?page=1&keywords=fullstack')
+      .expect('Content-Type', /application\/json/)
+      .expect(401);
+    });
+  });
+
+  describe('Testing /search/:api route', () => {
+    it('Can make get item requests from Muse', () => {
+      return request(server)
+      .get('/search/muse/5079123')
+      .expect('Content-Type', /application\/json/)
+      .expect(200);
+    });
+
+    it('Can make get item requests from Findwork.dev', () => {
+      return request(server)
+      .get('/search/findwork.dev/85799')
+      .expect('Content-Type', /application\/json/)
+      .expect(200);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "sass": "^1.35.1",
     "sass-loader": "^12.1.0",
     "style-loader": "^3.0.0",
+    "supertest": "^6.1.4",
     "ts-jest": "^27.0.3",
     "ts-loader": "^9.2.3",
     "ts-node": "^10.1.0",

--- a/server/server.ts
+++ b/server/server.ts
@@ -37,9 +37,11 @@ app.use((err: any, req: Request, res: Response, next: NextFunction) => {
   const { status, log, message } = err;
   console.log(err.log || 'Error: unknown error occurred');
 
-  return res.status(status || 500).send(message || 'An error occurred.');
+  return res.status(status || 500).json(message || 'An error occurred.');
 });
 
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
   console.log(`Listening to port ${PORT}...`);
 });
+
+export default server;


### PR DESCRIPTION
This PR adds supertest framework for testing back-end routes. You can test this PR by running `npm test`